### PR TITLE
add public twtr response

### DIFF
--- a/src/routes/webhook.js
+++ b/src/routes/webhook.js
@@ -48,6 +48,15 @@ class Client extends RingCentralEngage {
       in_reply_to_id: rid,
       ...messageObj
     }
+
+    if (event.resource.type === 'twtr/tweet') {
+      return this.get(`/1.0/identities/${event.resource.metadata.author_id}`)
+      .then(({data: { uuid }}) => this.post(`${url}?in_reply_to_id=${rid}&body=@${uuid} ${encodeURIComponent(messageObj.body)}`))
+      .catch(e => {
+        console.log(e)
+      })
+    }
+
     return this.post(url, reply).catch(e => {
       console.log(e)
     })


### PR DESCRIPTION
Public tweet response is posibble but if passing parameters in req.query and not in post body : 

`/1.0/contents?in_reply_to_id=xx&body=@username Hello`

It also needs the @username, i fetch it using get on identities since it is not in the Dimelo tweet event ( would like it tho .. )